### PR TITLE
watch expression needs an update

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This will place the following in your `Guardfile`:
 
 ```rb
 guard :cane do
-  watch(%r{^app/(.+)\.rb$})
+  watch(%r{^(.+)\.rb$})
 end
 ```
 


### PR DESCRIPTION
The current watch expression is not correct as it will incorrectly pickup files like coverage/_user.rb.html which might be generated by a code coverage tool as part of guard running the unit tests.  By specifying $ in the regular expression the watching is limited to .rb files
