### PR TITLE
Setting the title to Cane so you know what passed/failed

### DIFF
--- a/lib/guard/cane.rb
+++ b/lib/guard/cane.rb
@@ -8,8 +8,8 @@ module Guard
       run_all_on_start: true
     }
 
-    SUCCESS = ["Passed", { title: "Passed", image: :success }]
-    FAILED = ["Failed", { title: "Failed", image: :failed }]
+    SUCCESS = ["Passed", { title: "Cane", image: :success }]
+    FAILED = ["Failed", { title: "Cane", image: :failed }]
 
     attr_reader :last_result, :options
 


### PR DESCRIPTION
Currently the passing/failing notifications will only say "Passed Passed" or "Failed Failed". This way they will specify what passed or failed.

Let me know if you want me to write any tests for it. It didn't look like there were tests around what was passed to the notifier.
